### PR TITLE
feat: add CD pipeline for FastAPI deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Python CI/CD
+
+on:
+    pull_request:
+        branches:
+            - main
+    push:
+        branches:
+            - main
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements.txt
+                  pip install pytest pytest-asyncio httpx
+            - name: Run tests
+              run: |
+                  pytest tests/ -v
+
+    deploy:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements.txt
+
+            - name: Deploy to Production
+              env:
+                  SSH_PRIVATE_KEY: ${{ secrets.SERVER_KEY }}
+                  SERVER_USER: ${{ secrets.SERVER_USER }}
+                  SERVER_IP: ${{ secrets.SERVER_IP }}
+              run: |
+                  echo "$SSH_PRIVATE_KEY" > private_key && chmod 600 private_key
+                  ssh -o StrictHostKeyChecking=no -i private_key $SERVER_USER@$SERVER_IP "
+                      cd ~/HNGx-fastapi-book-project &&
+                      git pull origin main &&
+                      source venv/bin/activate &&
+                      pip install -r requirements.txt &&
+                      sudo systemctl restart fastapi
+                  "


### PR DESCRIPTION
## Description  
- Added CD pipeline for FastAPI deployment using GitHub Actions.  
- Configured Nginx as a reverse proxy.  


## Testing  
- Ran `pytest` locally (all tests passed).  
- CI/CD pipeline triggered successfully on PR creation.  

## Notes  
- Invited `hng12-devbotops` as a collaborator.  
- Deployment URL: `http://20.127.201.224/`  
